### PR TITLE
Pubs 1681 - Link to Google Analytics Metrics for each publication page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 -   Dockerfile and docker-compose scripts to build a pubswh-ui. This includes Jenkinsfile.build used to build the image
+-   Added a link to the google analytics metrics page on the publication page in the Additional Details table.
 
 [Unreleased]: https://github.com/NWQMC/WQP_UI/master

--- a/server/pubs_ui/pubswh/templates/pubswh/publication.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/publication.html
@@ -428,6 +428,10 @@
                             <td>{{ detail.values() | join(', ') | safe }}</td>
                         </tr>
                     {% endfor %}
+                    <tr>
+                        <th scope="row">Google Analytic Metrics</th>
+                        <td><a href="{{ url_for('metrics.publication', pubsid=indexID) }}">Metrics page</a></td>
+                    </tr>
                     </tbody>
                 </table>
             </section>


### PR DESCRIPTION
Before making a pull request
----------------------------

- [X] Make sure all tests run
- [X] Update the changelog appropriately

Title
-----------
Added link to the google analytics metrics page

Description
-----------
Rather than add this to the pubs details part of the pubsData record, I chose to just append
it to the table as it is simplier to format the link the template file.

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial