### PR TITLE
PUBSTWO-1691 Configure MathML with MathJax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 -   Using OAuth2 rather than a home rolled authentication.
 -   Using wdfn-viz rather than using USWDS directly. Note that this also means we are using USWDS version 2.x.x.
 -   Updated jasmine dependency to 3.4.0
+-   Updated MathJax config to support MathML (in addition to the original LaTeX)
 
 ### Added
 -   Dockerfile and docker-compose scripts to build a pubswh-ui. This includes Jenkinsfile.build used to build the image

--- a/server/pubs_ui/pubswh/templates/pubswh/mathjax.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/mathjax.html
@@ -1,5 +1,13 @@
-{# The two script tags below allow the the mathjax javascript engine to work on math elements of the page.  This allows for pretty, very accesible (508 compliant) math to appear on the page with little effort.
-to learn more, check out https://www.mathjax.org/ #}
+{# The two script tags below allow the the mathjax javascript engine to work on math elements of the page.
+   This allows for pretty, very accesible (508 compliant) math to appear on the page with little effort.
+   to learn more, check out https://www.mathjax.org/ #}
+
+{# download mathjax with both LaTex (TeX) and MathML (MML) support.  #}
+<script type="text/javascript" async
+  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
+</script>
+
+{# LaTex config for abstracts follows #}
 <script type="text/x-mathjax-config">
   MathJax.Hub.Config({
     extensions: ["tex2jax.js"],
@@ -11,5 +19,9 @@ to learn more, check out https://www.mathjax.org/ #}
     },
   });
 </script>
-<script type="text/javascript" src="{{ 'vendor/MathJax/MathJax.js' | asset_url }}"></script>
 
+{# polyfill is a CSS tool that has not been supported since 2016.
+   https://philipwalton.github.io/polyfill/
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+   This is loaded via local copy later.
+#}

--- a/server/pubs_ui/pubswh/templates/pubswh/mathjax.html
+++ b/server/pubs_ui/pubswh/templates/pubswh/mathjax.html
@@ -3,9 +3,7 @@
    to learn more, check out https://www.mathjax.org/ #}
 
 {# download mathjax with both LaTex (TeX) and MathML (MML) support.  #}
-<script type="text/javascript" async
-  src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/latest.js?config=TeX-MML-AM_CHTML">
-</script>
+<script type="text/javascript" src="{{ 'vendor/MathJax/MathJax.js' | asset_url }}?config=TeX-MML-AM_CHTML"></script>
 
 {# LaTex config for abstracts follows #}
 <script type="text/x-mathjax-config">
@@ -19,9 +17,3 @@
     },
   });
 </script>
-
-{# polyfill is a CSS tool that has not been supported since 2016.
-   https://philipwalton.github.io/polyfill/
-<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
-   This is loaded via local copy later.
-#}

--- a/server/pubs_ui/templates/base.html
+++ b/server/pubs_ui/templates/base.html
@@ -1,7 +1,7 @@
 {% import 'assets.html' as assets %}
 
 <!DOCTYPE html>
-<html lang="en">
+<html xmlns:mml="http://www.w3.org/1998/Math/MathML" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:ali="http://www.niso.org/schemas/ali/1.0/" xmlns:xi="http://www.w3.org/2001/XInclude" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" >
     <head lang="en">
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
MathJax was already in the application for LaTeX formula formats. This adds necessary config for MathML

Before making a pull request
----------------------------

- [x] Make sure all tests run
- [x] Update the changelog appropriately

Title
-----------
PUBSTWO-1691 Configure MathML with MathJax

Description
-----------
MathJax was already in the application for LaTeX formula formats. This adds necessary config for MathML

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial